### PR TITLE
(fix) "Update" secrets API call switch to PUT to fix functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,15 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.13
 
     - name: Run pylint
       uses: cclauss/GitHub-Action-for-pylint@0.7.0

--- a/main.py
+++ b/main.py
@@ -206,10 +206,6 @@ def add_dependabot_secret(token, target_repository, secret_name, secret_value, r
         print(f"dependabot Secret \"{secret_name}\" already exists in {repo_name}")
 
 def update_dependabot_secret(token, target_repository, secret_name, secret_value, repoOwner):
-    """Update a dependabot secret by delete (if exists) then PUT (create/update).
-
-    Ensures a value change actually propagates even if GitHub returns 204 for an unchanged value.
-    """
     repo_name = target_repository.name
     repo_owner = repoOwner
     headers = {
@@ -217,22 +213,6 @@ def update_dependabot_secret(token, target_repository, secret_name, secret_value
         'Accept': 'application/vnd.github+json'
     }
 
-    # # List existing secrets
-    # list_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets"
-    # list_resp = requests.get(list_url, headers=headers)
-    # try:
-    #     existing = flatten_secrets_dict(list_resp.json().get("secrets", []))
-    # except Exception:
-    #     existing = []
-
-    # # if secret_name in existing:
-    # #     del_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets/{secret_name}"
-    # #     del_resp = requests.delete(del_url, headers=headers)
-    # #     print(f"Delete (before update) Response Code: {del_resp.status_code}")
-    # #     if del_resp.status_code not in (204, 404):
-    # #         print(f"Warning: delete attempt returned status {del_resp.status_code}; continuing")
-
-    # Always PUT new value
     key_id, key = get_repo_public_key(token, repo_owner, repo_name)
     put_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets/{secret_name}"
     encrypted_value = encrypt(key, secret_value)

--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ def update_dependabot_secret(token, target_repository, secret_name, secret_value
             "encrypted_value": encrypt(key, secret_value),
             "key_id": key_id
         }
-        response = requests.patch(url, headers=headers, data=json.dumps(data))
+        response = requests.put(url, headers=headers, data=json.dumps(data))
         print(f"Response Code: {response.status_code}")
         if response.status_code == 204:
             print(f"dependabot Secret \"{secret_name}\" updated in {repo_name}")

--- a/main.py
+++ b/main.py
@@ -217,20 +217,20 @@ def update_dependabot_secret(token, target_repository, secret_name, secret_value
         'Accept': 'application/vnd.github+json'
     }
 
-    # List existing secrets
-    list_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets"
-    list_resp = requests.get(list_url, headers=headers)
-    try:
-        existing = flatten_secrets_dict(list_resp.json().get("secrets", []))
-    except Exception:
-        existing = []
+    # # List existing secrets
+    # list_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets"
+    # list_resp = requests.get(list_url, headers=headers)
+    # try:
+    #     existing = flatten_secrets_dict(list_resp.json().get("secrets", []))
+    # except Exception:
+    #     existing = []
 
-    if secret_name in existing:
-        del_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets/{secret_name}"
-        del_resp = requests.delete(del_url, headers=headers)
-        print(f"Delete (before update) Response Code: {del_resp.status_code}")
-        if del_resp.status_code not in (204, 404):
-            print(f"Warning: delete attempt returned status {del_resp.status_code}; continuing")
+    # # if secret_name in existing:
+    # #     del_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/dependabot/secrets/{secret_name}"
+    # #     del_resp = requests.delete(del_url, headers=headers)
+    # #     print(f"Delete (before update) Response Code: {del_resp.status_code}")
+    # #     if del_resp.status_code not in (204, 404):
+    # #         print(f"Warning: delete attempt returned status {del_resp.status_code}; continuing")
 
     # Always PUT new value
     key_id, key = get_repo_public_key(token, repo_owner, repo_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyGithub>=1.55
+PyGithub>=2.7.0


### PR DESCRIPTION
PUT request is supported for updating secrets, not patch.

Tested in internal repository.